### PR TITLE
Move @conn assignment inside mutex

### DIFF
--- a/lib/chain/conn.rb
+++ b/lib/chain/conn.rb
@@ -68,8 +68,8 @@ module Chain
     end
 
     def conn
-      @conn ||= establish_conn
       @conn_mutex.synchronize do
+        @conn ||= establish_conn
         begin
           return yield(@conn)
         rescue => e


### PR DESCRIPTION
There is a possible race condition here, I think.

If one thread's block raises an error, then
'#conn' rethrows that error, then the outer code catches
that error and continues running... while meanwhile
there is another thread waiting on that mutex block, @conn
will be set to nil.